### PR TITLE
Fixed spell Slice and Dice and Syntax error in core.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-# ![logo](http://www.trinitycore.org/f/public/style_images/1_trinitycore.png) TrinityCore
-
-`3.3.5`: [![3.3.5 Build Status](https://travis-ci.org/TrinityCore/TrinityCore.svg?branch=3.3.5)](https://travis-ci.org/TrinityCore/TrinityCore)
-
 ## Introduction
 ngen is based on the *MMORPG* framework Trinitycore.
 TrinityCore is a *MMORPG* Framework based mostly in C++.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,9 @@
 # ![logo](http://www.trinitycore.org/f/public/style_images/1_trinitycore.png) TrinityCore
 
-[![Coverity Scan Build Status](https://scan.coverity.com/projects/435/badge.svg)](https://scan.coverity.com/projects/435) 
-[![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=1310)](https://www.bountysource.com/trackers/1310-trinity-core?utm_source=1310&utm_medium=shield&utm_campaign=TRACKER_BADGE)  
-`6.x`: [![6.x Build Status](https://travis-ci.org/TrinityCore/TrinityCore.svg?branch=6.x)](https://travis-ci.org/TrinityCore/TrinityCore)
-`4.3.4`: [![4.3.4 Build Status](https://travis-ci.org/TrinityCore/TrinityCore.svg?branch=4.3.4)](https://travis-ci.org/TrinityCore/TrinityCore)
 `3.3.5`: [![3.3.5 Build Status](https://travis-ci.org/TrinityCore/TrinityCore.svg?branch=3.3.5)](https://travis-ci.org/TrinityCore/TrinityCore)
 
 ## Introduction
-
+ngen is based on the *MMORPG* framework Trinitycore.
 TrinityCore is a *MMORPG* Framework based mostly in C++.
 
 It is derived from *MaNGOS*, the *Massive Network Game Object Server*, and is
@@ -33,52 +29,3 @@ website at [TrinityCore.org](http://www.trinitycore.org).
 + OpenSSL ≥ 1.0.0
 + GCC ≥ 4.7.2 (Linux only)
 + MS Visual Studio ≥ 12 (2013) (Windows only)
-
-
-## Install
-
-Detailed installation guides are available in the wiki for
-[Windows](http://collab.kpsn.org/display/tc/Win),
-[Linux](http://collab.kpsn.org/display/tc/Linux) and
-[Mac OSX](http://collab.kpsn.org/display/tc/Mac).
-
-
-## Reporting issues
-
-Issues can be reported via the [Github issue tracker](https://github.com/TrinityCore/TrinityCore/issues?labels=Branch-3.3.5a).
-
-Please take the time to review existing issues before submitting your own to
-prevent duplicates.
-
-In addition, thoroughly read through the [issue tracker guide](http://www.trinitycore.org/f/topic/37-the-trinitycore-issuetracker-and-you/) to ensure
-your report contains the required information. Incorrect or poorly formed
-reports are wasteful and are subject to deletion.
-
-
-## Submitting fixes
-
-Fixes are submitted as pull requests via Github. For more information on how to
-properly submit a pull request, read the [how-to: maintain a remote fork](http://www.trinitycore.org/f/topic/6037-howto-maintain-a-remote-fork-for-pull-requests-tortoisegit/).
-
-
-## Copyright
-
-License: GPL 2.0
-
-Read file [COPYING](COPYING)
-
-
-## Authors &amp; Contributors
-
-Read file [THANKS](THANKS)
-
-
-## Links
-
-[Site](http://www.trinitycore.org)
-
-[Wiki](http://trinitycore.info)
-
-[Documentation](http://www.trinitycore.net) (powered by Doxygen)
-
-[Forums](http://www.trinitycore.org/f/)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -23301,7 +23301,7 @@ void Player::LearnDefaultSkills()
         LearnSpell(63644, true);
         LearnSpell(63645, true);
     }
-    UpdateSpecCount(2
+    UpdateSpecCount(2);
 }
 
 void Player::LearnDefaultSkill(uint32 skillId, uint16 rank)

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -163,9 +163,9 @@ DiminishingGroup GetDiminishingReturnsGroupForSpell(SpellInfo const* spellproto,
 		// Crippling poison - Limit to 10 seconds in PvP (No SpellFamilyFlags)
 		else if (spellproto->SpellIconID == 163)
 			return DIMINISHING_LIMITONLY;
-		// Slice and Dice
+		// Slice n Dice
 		else if (spellproto->SpellFamilyFlags[0] & 0x40000)
-			return true;
+			return DIMINISHING_NONE;
 		break;
 	}
 	case SPELLFAMILY_HUNTER:

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -163,6 +163,9 @@ DiminishingGroup GetDiminishingReturnsGroupForSpell(SpellInfo const* spellproto,
 		// Crippling poison - Limit to 10 seconds in PvP (No SpellFamilyFlags)
 		else if (spellproto->SpellIconID == 163)
 			return DIMINISHING_LIMITONLY;
+		// Slice and Dice
+		else if (spellproto->SpellFamilyFlags[0] & 0x40000)
+			return true;
 		break;
 	}
 	case SPELLFAMILY_HUNTER:


### PR DESCRIPTION
Now 'Slice and Dice' shouldn't put you in combat when used.

NOTE: Not tested.
